### PR TITLE
Basic Openlayers Example

### DIFF
--- a/Demo/index.html
+++ b/Demo/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"></meta>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.0.1/css/ol.css" type="text/css">
+    <style>
+      .map {
+        height: 1000px;
+        width: 100%;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.0.1/build/ol.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://astrowebmaps.wr.usgs.gov/webmapatlas/Layers/maps.js"></script>
+    <title>OpenLayers V6.0.1 w/ Custom Baselayer</title>
+  </head>
+  <body>
+    <h2>OpenLayers V6.0.1 w/ Custom Baselayer</h2>
+    <div id="map" class="map"></div>
+    <script>
+    var testLayer = myJSONmaps['targets'][142]["webmap"][0];
+    var testExtent = [testLayer["bounds"]["left"], testLayer["bounds"]["right"], testLayer["bounds"]["top"], testLayer["bounds"]["bottom"]];
+    var testProjection = testLayer["projection"];
+    var projection = "";
+
+    // North Polar Projection
+    var northPolarProjection = new ol.proj.Projection({
+      code: 'EPSG:32661',
+      //extent: [-2357032, -2357032, 2357032, 2357032],
+      worldExtent: [0, 60, 360, 90],
+      units: 'm'
+    })
+    ol.proj.addProjection(northPolarProjection);
+
+    // South Polar projection
+    var southPolarProjection = new ol.proj.Projection({
+      code: 'EPSG:32761',
+      //extent: [-2357032, -2357032, 2357032, 2357032],
+      worldExtent: [0, -90, 360, -60],
+      units: 'm'
+    })
+    ol.proj.addProjection(southPolarProjection);
+
+    switch(testProjection){
+      case("cylindrical"):
+        projection = "EPSG:4326";
+        break;
+
+      case("north-polar stereographic"):
+        projection = "EPSG:32661";
+        break;
+
+      default:
+        projection = "EPSG:32761";
+        break;
+    }
+
+    console.log(projection);
+
+    baseLayers = [];
+
+    myLayers = new ol.layer.Tile({
+                    title: 'Mars',
+                    type: 'base',
+                    source: new ol.source.TileWMS({
+                      //url: 'https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/mars/mars_simp_cyl.map',
+                      url: String(testLayer['url']) + '?map=' + String(testLayer['map']),
+                      //params:{ 'LAYERS':'MOLA_color'},
+                      params:{"LAYERS": String(testLayer["layer"])},
+                      serverType: 'mapserver',
+                      crossOrigin: 'anonymous'
+                    })
+                  })
+    baseLayers.push(myLayers)
+
+    var map = new ol.Map({
+      target: 'map',
+      layers: baseLayers,
+        view: new ol.View({
+        //extent: extent,
+        //projection: 'EPSG:4326',
+        projection: projection,
+        center: ol.proj.fromLonLat([37.41, 8.82]),
+        zoom: 4
+      })
+    });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Basic Openlayers map that gets layers from the web atlas. Currently hard coded to display a Mars layer.  Supports North/South Polar Stereographic projections and cylindrical projection. To run, simply open the index.html in your favorite browser. 